### PR TITLE
Added .finos.query.renameKeys[...] and .finos.query.renameCols[...].

### DIFF
--- a/query/query.q
+++ b/query/query.q
@@ -49,3 +49,18 @@
    ;ungroup t]}
 
 
+///
+// Rename keys of a dictionary without changing the order.
+.finos.query.renameKeys:{[mappingDict;inputDict]
+  fullMap:{x!x}[key inputDict],mappingDict;
+  r:fullMap[key inputDict]!value inputDict;
+  r}
+  
+
+
+///
+// Rename columns of a table without changing the order.
+.finos.query.renameCols:{[mappingDict;t]
+  r:flip .finos.query.renameKeys[mappingDict;flip t];
+  r}
+

--- a/query/test_query.q
+++ b/query/test_query.q
@@ -18,3 +18,12 @@
 asc[.test.t0syms]~asc ungroup .test.g0syms
 asc[.test.t1strs]~asc .finos.query.xungroup[`c1;.test.g1strs]
 asc[.test.t1strs]~asc .finos.query.ungroup .test.g1strs
+
+
+// dictionary to to get its keys renamed
+.test.dictToRename:`a`b`c!1 2 3
+.test.tabToRename:2#enlist .test.dictToRename
+.test.mappingDict:`a`b!`aa`bb
+
+(`aa`bb`c!1 2 3)~.finos.query.renameKeys[.test.mappingDict;.test.dictToRename]
+([]aa:1 1;bb:2 2;c:3 3)~.finos.query.renameCols[.test.mappingDict;.test.tabToRename]


### PR DESCRIPTION
THE FOLLOWING DISCLAIMER APPLIES TO ALL SOFTWARE CODE AND OTHER MATERIALS CONTRIBUTED IN CONNECTION WITH THIS SOFTWARE:
THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY OTHER REQUIRED LICENSE TERMS.
ONLY THE SOFTWARE CODE AND OTHER MATERIALS CONTRIBUTED IN CONNECTION WITH THIS SOFTWARE, IF ANY, THAT ARE ATTACHED TO (OR OTHERWISE ACCOMPANY) THIS SUBMISSION (AND ORDINARY COURSE CONTRIBUTIONS OF FUTURES PATCHES THERETO) ARE TO BE CONSIDERED A CONTRIBUTION. NO OTHER SOFTWARE CODE OR MATERIALS ARE A CONTRIBUTION.