### PR TITLE
Add Kdb Agenda and Minutes Template to KDB ISSUE_TEMPLATE folder 

### DIFF
--- a/.github/ISSUE_TEMPLATE/Meeting.md
+++ b/.github/ISSUE_TEMPLATE/Meeting.md
@@ -36,7 +36,7 @@ _// First Monday of every month_
 **Webex** 
 * https://finos.webex.com/finos/j.php?MTID=mfc9190e818fd85f9e3ece5166f23d920
 
-**Dial-in**
+**Dial-in and Project Materials**
 - **US:** +1-415-655-0003 US Toll
 - **UK:** +44-20319-88141 UK Toll
 - **Access code:** 663 746 304

--- a/.github/ISSUE_TEMPLATE/Meeting.md
+++ b/.github/ISSUE_TEMPLATE/Meeting.md
@@ -1,0 +1,44 @@
+---
+name: 🤝 KDB Project Call Meeting Agenda
+about: To track KDB Project meeting agenda and attendance
+---
+
+## Date
+Monday DD MMM yyyy - 10am EST / 3pm BST
+_//First Monday of every month_
+
+## Untracked attendees
+| Fullname | Affiliation | GitHub Username |
+|:-----|:-----|:-----|
+| | | |
+| | | |
+
+## Agenda
+
+- [ ] Convene, roll call, welcome new people
+- [ ] Review action items from previous meetings
+- [ ] Approve previous meeting minutes
+- [ ] _Add Items Here_
+- [ ] AOB, Q&A & Adjourn
+
+## Decisions Made
+- [ ] Decision 1
+- [ ] Decision 2
+- [ ] ...
+
+## Action Items
+- [ ] Action 1
+- [ ] Action 2
+- [ ] ...
+
+### WebEx info
+**Webex** 
+https://finos.webex.com/finos/j.php?MTID=mfc9190e818fd85f9e3ece5166f23d920
+
+**Dial-in**
+**US:** +1-415-655-0003 US Toll
+**UK:** +44-20319-88141 UK Toll
+**Access code:** 663 746 304
+
+**GitHub Repo:** https://github.com/finos/kdb
+**Project Wiki Page:** https://finosfoundation.atlassian.net/wiki/spaces/DT/pages/329383945/kdb+Project

--- a/.github/ISSUE_TEMPLATE/Meeting.md
+++ b/.github/ISSUE_TEMPLATE/Meeting.md
@@ -6,7 +6,7 @@ about: To track KDB Project meeting agenda and attendance
 ## Date
 Monday DD MMM yyyy - 10am EST / 3pm BST
 
-_//First Monday of every month_
+_// First Monday of every month_
 
 ## Untracked attendees
 | Fullname | Affiliation | GitHub Username |

--- a/.github/ISSUE_TEMPLATE/Meeting.md
+++ b/.github/ISSUE_TEMPLATE/Meeting.md
@@ -34,13 +34,11 @@ _// First Monday of every month_
 
 ### WebEx info
 **Webex** 
-
-https://finos.webex.com/finos/j.php?MTID=mfc9190e818fd85f9e3ece5166f23d920
+* https://finos.webex.com/finos/j.php?MTID=mfc9190e818fd85f9e3ece5166f23d920
 
 **Dial-in**
 - **US:** +1-415-655-0003 US Toll
 - **UK:** +44-20319-88141 UK Toll
 - **Access code:** 663 746 304
 - **GitHub Repo:** https://github.com/finos/kdb
-
-**Project Wiki Page:** https://finosfoundation.atlassian.net/wiki/spaces/DT/pages/329383945/kdb+Project
+- **Wiki Page:** https://finosfoundation.atlassian.net/wiki/spaces/DT/pages/329383945/kdb+Project

--- a/.github/ISSUE_TEMPLATE/Meeting.md
+++ b/.github/ISSUE_TEMPLATE/Meeting.md
@@ -40,5 +40,7 @@ _// First Monday of every month_
 - **US:** +1-415-655-0003 US Toll
 - **UK:** +44-20319-88141 UK Toll
 - **Access code:** 663 746 304
-- **GitHub Repo:** https://github.com/finos/kdb
-- **Wiki Page:** https://finosfoundation.atlassian.net/wiki/spaces/DT/pages/329383945/kdb+Project
+- **GitHub Repo:** 
+  - https://github.com/finos/kdb
+- **Wiki Page:** 
+  - https://finosfoundation.atlassian.net/wiki/spaces/DT/pages/329383945/kdb+Project

--- a/.github/ISSUE_TEMPLATE/Meeting.md
+++ b/.github/ISSUE_TEMPLATE/Meeting.md
@@ -5,6 +5,7 @@ about: To track KDB Project meeting agenda and attendance
 
 ## Date
 Monday DD MMM yyyy - 10am EST / 3pm BST
+
 _//First Monday of every month_
 
 ## Untracked attendees

--- a/.github/ISSUE_TEMPLATE/Meeting.md
+++ b/.github/ISSUE_TEMPLATE/Meeting.md
@@ -34,12 +34,13 @@ _// First Monday of every month_
 
 ### WebEx info
 **Webex** 
+
 https://finos.webex.com/finos/j.php?MTID=mfc9190e818fd85f9e3ece5166f23d920
 
 **Dial-in**
-**US:** +1-415-655-0003 US Toll
-**UK:** +44-20319-88141 UK Toll
-**Access code:** 663 746 304
+- **US:** +1-415-655-0003 US Toll
+- **UK:** +44-20319-88141 UK Toll
+- **Access code:** 663 746 304
+- **GitHub Repo:** https://github.com/finos/kdb
 
-**GitHub Repo:** https://github.com/finos/kdb
 **Project Wiki Page:** https://finosfoundation.atlassian.net/wiki/spaces/DT/pages/329383945/kdb+Project


### PR DESCRIPTION
### Description
This PR adds a GitHub Issue Template as markdown to the KDB project `.github\ISSUE_TEMPLATE` folder for the purpose of creating and updating KDB agendas and minutes.

### Additional Information
This PR directly relates to the activity outlined in https://github.com/finos/open-developer-platform/issues/161