### PR TITLE
fix formatting in dep readme

### DIFF
--- a/q/dep/README.md
+++ b/q/dep/README.md
@@ -11,13 +11,12 @@ A module is described using a name, version, project root, script path and libra
 
 ### High-level API
 * ```.finos.dep.loadFromRecord[rec]``` registers and optionally loads a module. It accepts a dictionary with the following keys:
-** ```name``` (string, mandatory): the name of the module
-** ```version``` (string, mandatory): the version of the module
-** ```resolver``` (symbol): the name of the resolver to use, see below
-** ```override``` (boolean): whether this is an override or not
-** ```lazy``` (boolean): if true, only register the module, don't load it
-** ```scripts``` (list of string): a list of scripts to load from the module, only allowed if ```lazy``` is false
-* 
+  * ```name``` (string, mandatory): the name of the module
+  * ```version``` (string, mandatory): the version of the module
+  * ```resolver``` (symbol): the name of the resolver to use, see below
+  * ```override``` (boolean): whether this is an override or not
+  * ```lazy``` (boolean): if true, only register the module, don't load it
+  * ```scripts``` (list of string): a list of scripts to load from the module, only allowed if ```lazy``` is false
 
 ### Resolvers
 Resolvers can be used to construct the projectRoot, scriptPath and libPath for a module. The default resolver (whose name is the null symbol) simply picks out the ```projectRoot```, ```scriptPath``` and ```libPath``` elements of the record, so when using this resolver, these are mandatory as well. To define custom resolvers, assign them in the dictionary ```.finos.dep.resolvers```. The resolver must be a function that takes a dictionary (the same one that is used as the parameter to ```.finos.dep.loadFromRecord```) and must return a dictionary with the keys ```projectRoot```, ```scriptPath``` and ```libPath```, with all three values being strings.


### PR DESCRIPTION
THE FOLLOWING DISCLAIMER APPLIES TO ALL SOFTWARE CODE AND OTHER MATERIALS CONTRIBUTED IN CONNECTION WITH THIS SOFTWARE:
THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY OTHER REQUIRED LICENSE TERMS.
ONLY THE SOFTWARE CODE AND OTHER MATERIALS CONTRIBUTED IN CONNECTION WITH THIS SOFTWARE, IF ANY, THAT ARE ATTACHED TO (OR OTHERWISE ACCOMPANY) THIS SUBMISSION (AND ORDINARY COURSE CONTRIBUTIONS OF FUTURES PATCHES THERETO) ARE TO BE CONSIDERED A CONTRIBUTION. NO OTHER SOFTWARE CODE OR MATERIALS ARE A CONTRIBUTION.