### PR TITLE
Update Project Time from BST to UK and EST to ET

### DIFF
--- a/.github/ISSUE_TEMPLATE/Meeting.md
+++ b/.github/ISSUE_TEMPLATE/Meeting.md
@@ -8,7 +8,7 @@ assignees: ''
 ---
 
 ## Date
-Monday, Month DD, YYYY - 9:30am EST / 2:30pm BST
+Monday, Month DD, YYYY - 9:30am ET / 2:30pm UK
 
 _// Second Monday of every month_
 


### PR DESCRIPTION
## Description
This PR changes the project time format due to be more flexible around US and UK daylight saving. This includes changing `BST` to `UK` and `EST` to `ET` as below ...

### From 
```
Monday, Month DD, YYYY - 9:30am EST / 2:30pm BST
```

### To 
```
Monday, Month DD, YYYY - 9:30am ET / 2:30pm UK
```