### PR TITLE
add workaround for .finos.dep.currentFile in 3.5/3.6

### DIFF
--- a/q/dep/README.md
+++ b/q/dep/README.md
@@ -42,7 +42,7 @@ If a file named ```qproject.json``` is found in the project root, it is processe
 
 ### include
 The include feature of FINOS Module Loader allows intra-project file dependency management. This is the underlying function used by all the script loading in the dep library, with the exception of ```.finos.dep.execScript(In)```.
-The core of this feature is the ```.finos.dep.include``` function which takes a string as a parameter and loads the specified file. Relative paths are considered to be relative to either the startup script or the file being loaded by the innermost include call - in other words, if you only use include to load your files, you can assume that relative paths are relative to the current file.
+The core of this feature is the ```.finos.dep.include``` function which takes a string as a parameter and loads the specified file. Relative paths are considered to be relative to either the startup script or the file being loaded by the innermost include call - in other words, if you only use include to load your files, you can assume that relative paths are relative to the current file. **In KDB 3.5/3.6, relative paths should only be used in the top-level script or a script itself being directly loaded by ```.finos.dep.include```.**
 The include function does deduplication - it won't load a file that has already been loaded.
 Circular includes will cause an exception.
 The most important points when using include with relative paths:

--- a/q/dep/include.q
+++ b/q/dep/include.q
@@ -54,8 +54,8 @@ if[0<count getenv`FINOS_DEPENDS_DEBUG; .finos.dep.handleErrors:0b];
 
 ///
 // Include the specified file. Path is relative to the initial script (.z.f) or the current file if it's being included. Files won't be included more than once.
-// This function should be used only outside of functions, and only in top-level scripts or in scripts included using this function.
-// It should not be used from scripts loaded using \l or wrappers around it.
+// For relative paths, this function should be used only outside of functions, and only in top-level scripts or in scripts included using this function.
+// On 3.6 and below, it should not be used from scripts loaded directly using \l or wrappers around it.
 // @param force If true, load this file even if already loaded
 // @param file File to include
 .finos.dep.includeEx:{[force;file]
@@ -77,12 +77,19 @@ if[0<count getenv`FINOS_DEPENDS_DEBUG; .finos.dep.handleErrors:0b];
         .finos.dep.loaded[path]:1b;
         .finos.dep.logfn ((count[.finos.dep.includeStack]-1)#" "),"include: loading file ",path;
         .finos.dep.includeStack:.finos.dep.includeStack,enlist path;
+        if[.z.K<4.0;
+            prevFile:.finos.dep.priv.currentFile;
+            .finos.dep.priv.currentFile:path;   //used by .finos.dep.currentFile
+        ];
         start:.z.P;
         $[.finos.dep.handleErrors;
             .finos.dep.safeevalfn[system;enlist"l ",path;.finos.dep.priv.errorHandler[path]];
             system"l ",path
         ];
         end:.z.P;
+        if[.z.K<4.0;
+            .finos.dep.priv.currentFile:prevFile;
+        ];
         .finos.dep.priv.stat[([]file:enlist path);`elapsedTime]:end-start;
         .finos.dep.includeStack:(count[.finos.dep.includeStack]-1)#.finos.dep.includeStack;
     ];

--- a/q/finos_init.q
+++ b/q/finos_init.q
@@ -1,14 +1,16 @@
 ///
-// Get name of current file that is being loaded via \l
-// @return The file path as a string, or :: if no \l is currently running.
-.finos.dep.currentFile:{
+// Get name of current file that is being loaded via \l (4.0) or .finos.dep.include (3.6 or earlier)
+// @return The file path as a string, or the start file (.z.f) if no \l / .finos.dep.include is running
+.finos.dep.currentFile:$[.z.K>=4.0;{
     bt:(.Q.btx .Q.Ll`)[;1;3];
+    show bt;
     l:first where bt like"\\l *";
     $[null l;
         string .z.f;    //this is needed to ensure any includes in the main script work properly
-                        //unfortunately this also cause the function to misbehave if called outside of a file load
+                        //unfortunately this also causes the function to misbehave if called outside of a file load
         //(::);
         3_bt l]};
+    {.finos.dep.priv.currentFile}];
 
 .finos.dep.pathSeparators:$[.z.o like "w*";"\\";"/"];
 .finos.dep.pathSeparator:$[.z.o like "w*";"\\";"/"];
@@ -28,8 +30,18 @@
     .finos.dep.pathSeparator sv paths};
 
 {
+    if[.z.K<4.0;
+        //check for existence, such that user can override with a more accurate path, e.g. without resolving symlinks
+        if[()~key`.finos.dep.root; .finos.dep.root:.finos.dep.cutPath[first -3#value{}][0]];
+        .finos.dep.priv.currentFile:.finos.dep.root,"/finos_init.q";
+    ];
+
     path:.finos.dep.cutPath[.finos.dep.currentFile[]][0];
     system"l ",.finos.dep.joinPath(path;"dep";"include.q");
     .finos.dep.include"dep/dep.q";
     .finos.dep.regModule["finos/kdb";"1.0";path;"";""];
+
+    if[.z.K<4.0;
+        .finos.dep.priv.currentFile:string .z.f;
+    ];
     }[];


### PR DESCRIPTION
THE FOLLOWING DISCLAIMER APPLIES TO ALL SOFTWARE CODE AND OTHER MATERIALS CONTRIBUTED IN CONNECTION WITH THIS SOFTWARE:
THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY OTHER REQUIRED LICENSE TERMS.
ONLY THE SOFTWARE CODE AND OTHER MATERIALS CONTRIBUTED IN CONNECTION WITH THIS SOFTWARE, IF ANY, THAT ARE ATTACHED TO (OR OTHERWISE ACCOMPANY) THIS SUBMISSION (AND ORDINARY COURSE CONTRIBUTIONS OF FUTURES PATCHES THERETO) ARE TO BE CONSIDERED A CONTRIBUTION. NO OTHER SOFTWARE CODE OR MATERIALS ARE A CONTRIBUTION.